### PR TITLE
update to 0.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.webjars</groupId>
     <artifactId>typeaheadjs</artifactId>
     <name>typeahead.js</name>
-    <version>0.10.3-SNAPSHOT</version>
+    <version>0.10.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>WebJar for typeahead.js</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>0.10.2</upstreamVersion>
+        <upstreamVersion>0.10.4</upstreamVersion>
         <sourceUrl>https://github.com/twitter/typeahead.js/archive</sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>


### PR DESCRIPTION
0.10.3 was buggy and 0.10.4 was released shorty afterward. We can probably just skip it.
