### PR TITLE
Added typeaheadjs-bundle shim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,12 @@
         <requirejs>
             {
                 "paths": {
-                    "typeaheadjs": "typeahead.jquery"
+                    "typeaheadjs": "typeahead.jquery",
+                    "typeaheadjs-bundle": "typeahead.bundle"
                 },
                 "shim": {
-                    "typeaheadjs": ["jquery"]
+                    "typeaheadjs": ["jquery"],
+                    "typeaheadjs-bundle": ["jquery"]
                 }
             }
         </requirejs>


### PR DESCRIPTION
Added typeaheadjs-bundle shim. The bundle verison also includes Bloodhound to support loading suggestions via XHR
